### PR TITLE
The AGPL is wrongly described in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Infinity Next is distributed under the [AGPL 3.0](http://choosealicense.com/lice
 In short:
 * You may use Infinity Next for any reason you please.
 * You may modify Infinity Next as you see fit.
-* You may distribute modifications of Infinity Next with the same license.
+* You must distribute modifications of Infinity Next with the same license if you run the code in public.
 * You may profit with Infinity Next.
 
 However, you also agree that:


### PR DESCRIPTION
The AGPL license mandates you to share modifications, actually, because network use is redistribution.

      13. Remote Network Interaction; Use with the GNU General Public License.

      Notwithstanding any other provision of this License, if you modify the
    Program, your modified version must prominently offer all users
    interacting with it remotely through a computer network (if your version
    supports such interaction) an opportunity to receive the Corresponding
    Source of your version by providing access to the Corresponding Source
    from a network server at no charge, through some standard or customary
    means of facilitating copying of software.  This Corresponding Source
    shall include the Corresponding Source for any work covered by version 3
    of the GNU General Public License that is incorporated pursuant to the
    following paragraph.

The README at the current time describes the GPLv3 license. I believe this is an omission.