### PR TITLE
Fix uploaded filenames being interpreted as HTML, part one. #199

### DIFF
--- a/public/static/js/app/widgets/postbox.widget.js
+++ b/public/static/js/app/widgets/postbox.widget.js
@@ -232,8 +232,8 @@
 					
 					$preview
 						.addClass('dz-success')
-						.append("<input type=\"hidden\" name=\""+widget.options.dropzone.paramName+"[hash][]\" value=\""+file.hash+"\" />")
-						.append("<input type=\"hidden\" name=\""+widget.options.dropzone.paramName+"[name][]\" value=\""+file.name+"\" />")
+						.append($("<input type=\"hidden\" />").attr('name', widget.options.dropzone.paramName+"[hash][]").val(file.hash))
+						.append($("<input type=\"hidden\" />").attr('name', widget.options.dropzone.paramName+"[name][]").val(file.name))
 					;
 					
 					$("[data-dz-spoiler]", $preview)


### PR DESCRIPTION
This should fix the most common case of #199.

For the second part (the [banned file message](https://github.com/infinity-next/infinity-next/blob/738b7042064f6629221dd6f6af0555b4f4d4bd45/public/static/js/app/widgets/postbox.widget.js#L147)), I wanted to get your thoughts on https://github.com/infinity-next/infinity-next/issues/199#issuecomment-166611056.