### PR TITLE
Disconnect MutationObserver when we're done with it.

### DIFF
--- a/public/static/js/app/main.js
+++ b/public/static/js/app/main.js
@@ -574,6 +574,11 @@
 					}
 				}
 			}
+
+			if (document.readyState !== "loading")
+			{
+				ib.mutationObserver.disconnect();
+			}
 		};
 		
 		// Widgets not fully loaded are queued for binding at a later time.


### PR DESCRIPTION
Otherwise the callback is needlessly run whenever something is changed on the
page (for example, the updater countdown).

Disconnecting in the `ready` callback isn't safe because if it happens before
the last invocation of the mutation observer callback, the mutation observer's
queue is cleared.