### PR TITLE
Fix banners section in /cp/board/test/assets in Firefox ESR.

### DIFF
--- a/public/static/css/app/main.css
+++ b/public/static/css/app/main.css
@@ -569,6 +569,7 @@ main.cp form.form-config {
 	min-width: 760px;
 	margin: 0 auto 0 0;
 	border-bottom: 1px solid #EEF2FF;
+	clear: left;
 }
 	form.form-config#config-site {
 		max-width: none;


### PR DESCRIPTION
Section was not wrapping to next line properly.
May be specific to Firefox < 42, but easy to work around.

![wrapfail](https://cloud.githubusercontent.com/assets/5894749/11996798/e5da675e-aa1f-11e5-9912-369f316cd669.png)