### PR TITLE
Fix download links and video controls not receiving clicks when comment is too long.

### DIFF
--- a/public/static/css/app/main.css
+++ b/public/static/css/app/main.css
@@ -2687,7 +2687,6 @@ main.index-threaded {
 			} */
 		
 		.post {
-			position: relative;
 			font-size: 105%;
 			margin: 0;
 			padding: 0.7em;


### PR DESCRIPTION
For some reason the combination of a `float: left` followed by a `position: relative` seems to cause this.

This issue I don't think is engine-specific, as I've seen it in both Gecko and Blink.
To reproduce, make a post with an attachement, with the comment long enough to extend past the download link or video controls.

I didn't notice a reason to have this be `position: relative`, but if there was something I missed, feel free to reject this and fix it a different way.  An alternate solution that seems to work is to add

    z-index: 5;
    position: relative;

to `ul.post-attachments`.