### PR TITLE
Fix postbox widget resizable and draggable binding on window resize

### DIFF
--- a/public/static/js/app/widgets/postbox.widget.js
+++ b/public/static/js/app/widgets/postbox.widget.js
@@ -319,7 +319,18 @@
 		}
 		else if (window.innerHeight >= 480 && window.innerWidth >= 728)
 		{
-			widget.bindResize();
+			var isClosed = $widget.hasClass("postbox-closed");
+			var isMaximized = $widget.hasClass("postbox-maximized");
+			
+			if (!isMaximized && !isClosed)
+			{
+				widget.bindResize();
+			}
+			
+			if (!isMaximized)
+			{
+				widget.bindDraggable();
+			}
 		}
 	};
 	


### PR DESCRIPTION
This pr fixes two issues in the postbox widget's `resizePostbox()` method.

First, when the postbox collapses into its fixed state at the top of the page and later reverts back to its floating state, the draggable handle widget isn't rebound meaning you cannot move the postbox until you open and close it.

Secondly, if the postbox is collapsed in its closed state, the resizable widget is rebound when the postbox reverts to its floating state meaning that when the postbox is opened, the textarea and resizer widget are much smaller than the rest of the postbox because the resizer widget uses the textarea dimensions when it isn't displayed.

These are fixed by adding a check in the `resizePostbox()` method to see if the draggable and resizable widgets should be rebound when the postbox reverts to its floating state.

I've tested these changes by modifying the JavaScript served from `beta.8ch.net` but I haven't had the opportunity to test them in a full Infinity-Next install