### PR TITLE
Misc Install Fixes

### DIFF
--- a/database/migrations/2016_01_18_213303_captcha_index.php
+++ b/database/migrations/2016_01_18_213303_captcha_index.php
@@ -21,8 +21,11 @@ class CaptchaIndex extends Migration
 		Schema::table('captcha', function(Blueprint $table)
 		{
 			$table->inet('client_ip')->after('hash')->nullable();
-			$table->index('client_ip');
-			$table->index('hash');
+			if (!(DB::connection() instanceof \Illuminate\Database\MySqlConnection))
+			{
+				$table->index('client_ip');
+				$table->index('hash');
+			}
 		});
 	}
 	
@@ -35,8 +38,11 @@ class CaptchaIndex extends Migration
 	{
 		Schema::table('captcha', function(Blueprint $table)
 		{
-			$table->dropIndex('captcha_client_ip_index');
-			$table->dropIndex('captcha_hash_index');
+			if (!(DB::connection() instanceof \Illuminate\Database\MySqlConnection))
+			{
+				$table->dropIndex('captcha_client_ip_index');
+				$table->dropIndex('captcha_hash_index');
+			}
 			$table->dropColumn('client_ip');
 			$table->binary('client_ip')->after('hash')->nullable();
 		});

--- a/database/seeds/PermissionSeeder.php
+++ b/database/seeds/PermissionSeeder.php
@@ -48,6 +48,7 @@ class PermissionSeeder extends Seeder {
 			"board.bans",
 			"board.logs",
 			"board.create",
+			"board.create.banned",
 			"board.delete",
 			"board.history",
 			"board.reassign",


### PR DESCRIPTION
**1. Fix: Constraint Violation when running "php artisan db:seed"**
The `boards.create.banned` permission id wasn't present in the list of permissions, causing the permission id groups table constraint to fail.

**2. Workaround: SQL Error when running "php artisan migrate" on mysql**
*(see #235) for an example of this*

The captcha table sets an index on the `client_ip` and `hash` columns. MySQL requires blob and text columns have an index length set when they are indexed.

Unfortunately this requires both a raw query (despite the various issues people have filed to get the Laravel ORM to allow this) but also a known maximum length for the data which isn't guaranteeable for the hash column. So the workaround is not to create an index for the table like before when using MySQL until a better solution can be found.