### PR TITLE
Fix for .hljs code boxes in next-tomorrow.css

### DIFF
--- a/public/static/css/skins/next-tomorrow.css
+++ b/public/static/css/skins/next-tomorrow.css
@@ -429,6 +429,20 @@ li.post-attachment {
    padding: 0 1em 5px 2px;
    display: inline-block;
 }
+
+/*Fix for Code Blocks, STOP BURNING MY RETINAS!*/
+
+.hljs {
+    background: #000;
+    color: #C5C8C6;
+}
+.hljs-tag {
+    color: #C5C8C6
+}
+.actions {
+    background-color: #333;
+}
+
 /*Fix attachment scrollbars*/
 ul.post-attachments {
     overflow: hidden !important;


### PR DESCRIPTION
Recommended change from https://9chan.tw/9/thread/1867#2157 , as code blocks still use a white background. Many retinas were seared, possibly lost.

Before

![Screenshot_20200426_184748](https://user-images.githubusercontent.com/52358618/80321844-8580d300-87ee-11ea-972e-a058797876fb.png)

After
![Screenshot_20200426_184449](https://user-images.githubusercontent.com/52358618/80321821-4fdbea00-87ee-11ea-8f18-97496e8a023b.png)
