### PR TITLE
Fix for .hljs code boxes in next-tomorrow.css

### DIFF
--- a/public/static/css/skins/next-tomorrow.css
+++ b/public/static/css/skins/next-tomorrow.css
@@ -433,7 +433,7 @@ li.post-attachment {
 /*Fix for Code Blocks, STOP BURNING MY RETINAS!*/
 
 .hljs {
-    background: #101112;
+    background: #282A2E;
     color: #C5C8C6;
 }
 .hljs-tag {

--- a/public/static/css/skins/next-tomorrow.css
+++ b/public/static/css/skins/next-tomorrow.css
@@ -433,7 +433,7 @@ li.post-attachment {
 /*Fix for Code Blocks, STOP BURNING MY RETINAS!*/
 
 .hljs {
-    background: #000;
+    background: #101112;
     color: #C5C8C6;
 }
 .hljs-tag {

--- a/public/static/css/skins/next-tomorrow.css
+++ b/public/static/css/skins/next-tomorrow.css
@@ -429,6 +429,20 @@ li.post-attachment {
    padding: 0 1em 5px 2px;
    display: inline-block;
 }
+
+/*Fix for Code Blocks, STOP BURNING MY RETINAS!*/
+
+.hljs {
+    background: #000;
+    color: #C5C8C6;
+}
+.hljs-tag {
+    color: #C5C8C6
+}
+.actions {
+    background-color: #333;
+}
+
 /*Fix attachment scrollbars*/
 ul.post-attachments {
     overflow: hidden !important;


### PR DESCRIPTION
Updated revision to PR #315 I closed a few days ago.

.hljs code boxes (formatted code in posts & replies) for next-tomorrow.css retained a white background, this darkens it in line with the theme. Issue found by an anon on 9Chan.tw