### PR TITLE
Fix undefined ContentFormatter bug

### DIFF
--- a/app/Post.php
+++ b/app/Post.php
@@ -579,6 +579,7 @@ class Post extends Model implements FormattableContract, Htmlable, Jsonable
             // If our body is too long, we need to pull the first X characters and do that instead.
             // We also set a token indicating this post has hidden content.
             if (mb_strlen($this->body) > 1200) {
+                $ContentFormatter = new ContentFormatter();
                 $this->body_too_long = true;
                 $this->body_parsed_preview = $ContentFormatter->formatPost($this, 1000);
             }


### PR DESCRIPTION
Just made a fix to the system if the post had no markdown and was over 1200 characters long, you'd get a 500 error.

There was a stickied thread on Choroy that would trigger this.